### PR TITLE
Parameter substitution fixes

### DIFF
--- a/pydantic_i18n/main.py
+++ b/pydantic_i18n/main.py
@@ -25,12 +25,6 @@ class PydanticI18n:
         self.default_locale = default_locale
         self._patterns = BabelRegex(self.source.get_translations(self.default_locale))
 
-    def _init_pattern(self) -> Pattern[str]:
-        keys = list(self.source.get_translations(self.default_locale))
-        return re.compile(
-            "|".join("({})".format(i.replace("{}", "(.+)")) for i in keys)
-        )
-
     def _translate(self, message: str, locale: str) -> str:
         source_msg_pattern = self._patterns.get(message)
         if source_msg_pattern:

--- a/pydantic_i18n/main.py
+++ b/pydantic_i18n/main.py
@@ -1,9 +1,15 @@
 import json
 import re
 from string import Formatter
-from typing import TYPE_CHECKING, Callable, Dict, List, Pattern, Sequence, Union
+from typing import TYPE_CHECKING
+from typing import Callable
+from typing import Dict
+from typing import List
+from typing import Sequence
+from typing import Union
 
-from .loaders import BaseLoader, DictLoader
+from .loaders import BaseLoader
+from .loaders import DictLoader
 from .types import BabelRegex
 
 if TYPE_CHECKING:  # pragma: no cover

--- a/pydantic_i18n/main.py
+++ b/pydantic_i18n/main.py
@@ -34,12 +34,14 @@ class PydanticI18n:
     def _translate(self, message: str, locale: str) -> str:
         source_msg_pattern = self._patterns.get(message)
         if source_msg_pattern:
+            target_msg_pattern = self.source.gettext(source_msg_pattern, locale=locale)
             expression = self._patterns.expression(source_msg_pattern)
             expression_compiled = re.compile(expression)
             match = re.match(pattern=expression_compiled, string=message)
-            groups = match.groups()
-            target_msg_pattern = self.source.gettext(source_msg_pattern, locale=locale)
-            return Formatter().format(target_msg_pattern, *groups)
+            if match:
+                groups = match.groups()
+                return Formatter().format(target_msg_pattern, *groups)
+            return target_msg_pattern
         return message
 
     @property

--- a/pydantic_i18n/types.py
+++ b/pydantic_i18n/types.py
@@ -1,5 +1,7 @@
 import re
-from typing import Any, Mapping, Optional
+from typing import Any
+from typing import Mapping
+from typing import Optional
 
 
 class RegexDict(dict):

--- a/pydantic_i18n/types.py
+++ b/pydantic_i18n/types.py
@@ -1,0 +1,42 @@
+import re
+from typing import Any, Mapping, Optional
+
+
+class RegexDict(dict):
+    def __getitem__(self, item: str):
+        for k, v in self.items():
+            if re.match(k, item):
+                return v
+        raise KeyError(item)
+
+    def get(self, key: str, default: Optional[Any] = None):
+        try:
+            return self.__getitem__(key)
+        except KeyError:
+            return default
+
+
+class BabelRegex(RegexDict):
+    def __init__(self, mapping: Mapping[str, Any] = None, /, **kwargs):
+        if mapping is not None:
+            mapping = {
+                "{}".format(key.replace("{}", "(.+)")): value
+                for key, value in mapping.items()
+            }
+        else:
+            mapping = {}
+        if kwargs:
+            mapping.update(
+                {
+                    "{}".format(key.replace("{}", "(.+)")): value
+                    for key, value in kwargs.items()
+                }
+            )
+        super(BabelRegex, self).__init__(mapping)
+
+    def __setitem__(self, key, value):
+        super(BabelRegex, self).__setitem__(self.expression(key), value)
+
+    @classmethod
+    def expression(cls, key: str):
+        return "{}".format(key.replace("{}", "(.+)"))

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -3,8 +3,11 @@ from typing import Dict
 
 import pytest
 
-from pydantic import BaseModel, ValidationError
-from pydantic_i18n import BaseLoader, DictLoader, PydanticI18n
+from pydantic import BaseModel
+from pydantic import ValidationError
+from pydantic_i18n import BaseLoader
+from pydantic_i18n import DictLoader
+from pydantic_i18n import PydanticI18n
 
 translations = {
     "en_US": {
@@ -164,3 +167,7 @@ def test_last_key_without_placeholder():
     translated_errors = tr.translate(e.value.errors(), locale=locale)
 
     assert _translations[locale][message] == translated_errors[0]["msg"]
+
+
+def test_not_found_translate(tr: PydanticI18n):
+    assert tr._translate("what is this?", locale="es_AR")

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -1,7 +1,8 @@
 import re
 from string import Formatter
 
-from pydantic_i18n.types import BabelRegex, RegexDict
+from pydantic_i18n.types import BabelRegex
+from pydantic_i18n.types import RegexDict
 
 
 def test_regex_dict_get():

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -11,7 +11,7 @@ def test_regex_dict_get():
             "value is not valid integer": "value is not valid integer",
             "address (.+) is not support": "address {} is not support",
             "image (.+) is not valid (.+) for (.+)": "image {} is not valid {} for {}",
-        }
+        },
     )
     assert storage.get("address foo@bar.com is not support") is not None
     assert storage.get("image <object> is not valid object for bucket") is not None
@@ -38,7 +38,9 @@ def test_babel_regex_insert_get():
             "value is not valid integer": "value is not valid integer",
             "address {} is not support": "address {} is not support",
             "image {} is not valid {} for {}": "image {} is not valid {} for {}",
-        }
+        },
+        key="value",
+        another_key="another key"
     )
     storage["text {} in message not supported"] = "text {} in message not supported"
 

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -1,0 +1,71 @@
+import re
+from string import Formatter
+
+from pydantic_i18n.types import BabelRegex, RegexDict
+
+
+def test_regex_dict_get():
+    storage = RegexDict(
+        {
+            "value is not valid integer": "value is not valid integer",
+            "address (.+) is not support": "address {} is not support",
+            "image (.+) is not valid (.+) for (.+)": "image {} is not valid {} for {}",
+        }
+    )
+    assert storage.get("address foo@bar.com is not support") is not None
+    assert storage.get("image <object> is not valid object for bucket") is not None
+    assert storage["address foo@bar.com is not support"] is not None
+    assert storage["image <object> is not valid object for bucket"] is not None
+
+
+def test_babel_regex_expression():
+    storage = BabelRegex()
+
+    exp1_input = "image {} is not valid {} for {}... {}...."
+    exp1_output = "image (.+) is not valid (.+) for (.+)... (.+)...."
+
+    exp2_input = "image not found"
+    exp2_output = "image not found"
+
+    assert storage.expression(exp1_input) == exp1_output
+    assert storage.expression(exp2_input) == exp2_output
+
+
+def test_babel_regex_insert_get():
+    storage = BabelRegex(
+        {
+            "value is not valid integer": "value is not valid integer",
+            "address {} is not support": "address {} is not support",
+            "image {} is not valid {} for {}": "image {} is not valid {} for {}",
+        }
+    )
+    storage["text {} in message not supported"] = "text {} in message not supported"
+
+    assert storage.get("address foo@bar.com is not support") is not None
+    assert storage.get("image <object> is not valid object for bucket") is not None
+    assert storage.get("text ABC-102-120 in message not supported") is not None
+    assert storage["address foo@bar.com is not support"] is not None
+    assert storage["image <object> is not valid object for bucket"] is not None
+    assert storage["text ABC-102-120 in message not supported"] is not None
+
+    assert storage.get("type integer not found") is None
+    assert storage.get("type integer not found", "Not Found") == "Not Found"
+
+
+def test_babel_regex_parser():
+    storage = BabelRegex(
+        {
+            "image {} is not valid {} for {}": "image {} is not valid {} for {}",
+        }
+    )
+    error_message = "image foo.png is not valid mimetype for dev/null"
+
+    error_pattern = storage.get(error_message)
+    #
+    error_pattern_expression = storage.expression(error_pattern)
+
+    error_pattern_expression_compiled = re.compile(error_pattern_expression)
+    match = re.match(pattern=error_pattern_expression_compiled, string=error_message)
+    params = match.groups()
+    assert params == ("foo.png", "mimetype", "dev/null")
+    assert Formatter().format(error_pattern, *params) == error_message


### PR DESCRIPTION
## Fixed:
1. The impossibility of using two or more substitution values.
```
template: value {} is not valid {}
template: value {} is not valid {} and {}
etc...
```

2. Substitution of a word-value that is present in the template string.
```
template: value {} is not valid integer
input: value integer is not valid integer
output pattern: value {} is not valid {}

template: value {} is not valid integer
input: value value is not valid integer
output pattern: {} {} is not valid integer
```
## Removed and replaced:

Removed `_init_pattern` and replaced with custom types `RegexDict`, `BabelRegex`.
`RegexDict` inherits from a `dict`.
Allows you to find a value by a string that matches the regex key.
`BabelRegex` allows you to create a key value pair from
`"value {} is not integer": "value {} is not integer"`
to
`"value (.+) is not integer": "value {} is not integer"`