### PR TITLE
🐛 Fix handling regexp-chars in translation keys (#216)

### DIFF
--- a/pydantic_i18n/main.py
+++ b/pydantic_i18n/main.py
@@ -26,7 +26,7 @@ class PydanticI18n:
     def _init_pattern(self) -> Pattern[str]:
         keys = list(self.source.get_translations(self.default_locale))
         return re.compile(
-            "|".join("({})".format(i.replace("{}", "(.+)")) for i in keys)
+            "|".join("({})".format(re.escape(i).replace(r"\{\}", "(.+)")) for i in keys)
         )
 
     def _translate(self, message: str, locale: str) -> str:

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -241,5 +241,7 @@ def test_valid_regexp():
     tr = PydanticI18n(_translations)
 
     locale = "de_DE"
-    translated_errors = tr.translate([{"msg": "This contains [a] regexp"}], locale=locale)
+    translated_errors = tr.translate(
+        [{"msg": "This contains [a] regexp"}], locale=locale
+    )
     assert translated_errors[0]["msg"] == "Hier ist [eine] regexp"

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -213,3 +213,33 @@ def test_multiple_placeholders():
         translated_errors[0]["msg"]
         == "Tupel sollte nach der Validierung höchstens 2 Elemente haben, nicht 3"
     )
+
+
+def test_invalid_regexp():
+    _translations = {
+        "en_US": {
+            "This contains a partial [ regexp": "This contains a partial [ regexp",
+        },
+        "de_DE": {
+            "This contains a partial [ regexp": "Hier ist eine partielle [ regexp",
+        },
+    }
+    # all we test here is that loading doesn't crash
+    PydanticI18n(_translations)
+
+
+def test_valid_regexp():
+    _translations = {
+        "en_US": {
+            "This contains [a] regexp": "This contains [a] regexp",
+        },
+        "de_DE": {
+            "This contains [a] regexp": "Hier ist [eine] regexp",
+        },
+    }
+
+    tr = PydanticI18n(_translations)
+
+    locale = "de_DE"
+    translated_errors = tr.translate([{"msg": "This contains [a] regexp"}], locale=locale)
+    assert translated_errors[0]["msg"] == "Hier ist [eine] regexp"


### PR DESCRIPTION
This commit fixes handling of translation strings that contain characters
that have a special meaning within regular expressions